### PR TITLE
Handle Posts with Null Titles

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ hexo.extend.migrator.register('rss', function(args, callback){
 
   var log = hexo.log,
     post = hexo.post,
+    untitledPostCounter = 0,
     stream;
 
   // URL regular expression from: http://blog.mattheworiordan.com/post/13174566389/url-regular-expression-for-links-with-or-without-the
@@ -45,6 +46,16 @@ hexo.extend.migrator.register('rss', function(args, callback){
       item;
 
     while (item = stream.read()){
+
+      if(!item.title) {
+        untitledPostCounter += 1;
+        var untitledPostTitle = "Untitled Post - " + untitledPostCounter
+        item.title = untitledPostTitle;
+        log.w("Post found but without any titles. Using %s", untitledPostTitle)
+      } else {
+        log.i('Post found: %s', item.title);
+      }
+
       posts.push({
         title: item.title,
         date: item.date,
@@ -52,7 +63,6 @@ hexo.extend.migrator.register('rss', function(args, callback){
         content: tomd(item.description)
       });
 
-      log.i('Post found: %s', item.title);
     }
   });
 
@@ -62,6 +72,7 @@ hexo.extend.migrator.register('rss', function(args, callback){
     }, function(err){
       if (err) return callback(err);
 
+      log.w('%d posts did not have titles and were prefixed with "Untitled Post".', untitledPostCounter);
       log.i('%d posts migrated.', posts.length);
       callback();
     });


### PR DESCRIPTION
Sometimes posts can have no title. Really old blogs have these since platforms were not smart enough to stop such idiocies from happening. When trying to migrate, we're going to end up throwing up a whole set of mess since hexo (rightly so, always expects a title and cries like a baby when there's none).

This should make things a bit more sane. Tried it out with my blog and it worked. Not sure if rest of the stuff (date, categories, description) need to be worked upon as well.