### PR TITLE
avoid crash when description is empty

### DIFF
--- a/migrator.js
+++ b/migrator.js
@@ -62,7 +62,7 @@ exports.registerMigrator = function (hexo) {
           title: item.title,
           date: item.date,
           tags: item.categories,
-          content: tomd(item.description)
+          content: tomd(item.description || '')
         };
 
         if (args.alias) {


### PR DESCRIPTION
When description is empty.
```
<description>
  <![CDATA[ ]]>
</description>
```
there will be an error 
```
/Users/xiongliding/blog/node_modules/to-markdown/src/to-markdown.js:95
      markdown = html.replace(regex, function(str, p1, p2, p3) {
                     ^

TypeError: Cannot read property 'replace' of null
```