### PR TITLE
chore(deps): use caret versioning for feedparser

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "async": "^3.1.0",
-    "feedparser": "2.2.9",
+    "feedparser": "^2.2.9",
     "request": "^2.36.0",
     "to-markdown": "0.0.1",
     "url": "^0.11.0"


### PR DESCRIPTION
package.json only needs to be updated whenever a major version is released.