### PR TITLE
fix(request): url must start with http:// or https://

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -29,7 +29,7 @@ exports.registerMigrator = function(hexo) {
     let stream;
 
     // URL regular expression from: http://blog.mattheworiordan.com/post/13174566389/url-regular-expression-for-links-with-or-without-the
-    if (source.match(/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[.!/\\w]*))?)/)) {
+    if (/^http(s)?:\/\//i.test(source)) {
       stream = request(source);
     } else {
       stream = fs.createReadStream(source);


### PR DESCRIPTION
BREAKING CHANGE: link without http (e.g. www.example.com) no longer works

Current regex matches IDN http://www.好.com, but not www.好.com. It also matches email address, which is irrelevant to this plugin.

This PR simplifies the regex to match http:// and https:// only, "request" only support these protocols.