### PR TITLE
feat(skipduplicate): option to skip existing posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,8 @@ $ hexo migrate rss <source> [--options]
   ``` bash
   $ hexo migrate rss /path/atom.xml --limit 3
   ```
+- **skipduplicate**: Skip posts with similar title as existing ones.
+  * If a feed contains a post titled 'Foo Bar' and there is an existing post named 'Foo-Bar.md', then that post will not be migrated.
+  * The comparison is case-insensitive; a post titled 'FOO BAR' will be skipped if 'foo-bar.md' exists.
 
 [Hexo]: https://hexo.io/

--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ $ hexo migrate rss <source> [--options]
 - **skipduplicate**: Skip posts with similar title as existing ones.
   * If a feed contains a post titled 'Foo Bar' and there is an existing post named 'Foo-Bar.md', then that post will not be migrated.
   * The comparison is case-insensitive; a post titled 'FOO BAR' will be skipped if 'foo-bar.md' exists.
+  * Without this option (default), this plugin will continue to migrate that post and create a post named 'Foo-Bar-1.md'
 
 [Hexo]: https://hexo.io/

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -2,21 +2,26 @@
 
 const TurndownService = require('turndown');
 const got = require('got');
-const { parse } = require('url');
-const { readFile } = require('hexo-fs');
+const { parse: parseUrl } = require('url');
+const { exists, listDir, readFile } = require('hexo-fs');
 const parseFeed = require('./feed');
+const { slugize } = require('hexo-util');
+const { join, parse } = require('path');
 
 module.exports = async function(args) {
   const source = args._.shift();
   const { alias } = args;
+  const skipduplicate = typeof args.skipduplicate !== 'undefined';
   let { limit } = args;
   const tomd = new TurndownService();
-  const { log } = this;
+  const { config, log } = this;
   const Post = this.post;
   let untitledPostCounter = 0;
   let errNum = 0;
+  let skipNum = 0;
   let input, feed;
   const posts = [];
+  let currentPosts = [];
 
   try {
     if (!source) {
@@ -70,15 +75,28 @@ module.exports = async function(args) {
       };
 
       if (alias && link) {
-        newPost.alias = parse(link).pathname;
+        newPost.alias = parseUrl(link).pathname;
       }
 
       posts.push(newPost);
     }
   }
 
+  if (skipduplicate) {
+    const postFolder = join(config.source_dir, '_posts');
+    const folderExist = await exists(postFolder);
+    const files = folderExist ? await listDir(join(config.source_dir, '_posts')) : [];
+    currentPosts = files.map(file => slugize(parse(file).name, { transform: 1 }));
+  }
+
   if (posts.length >= 1) {
     for (const post of posts) {
+      if (currentPosts.length && skipduplicate) {
+        if (currentPosts.includes(slugize(post.title, { transform: 1 }))) {
+          skipNum++;
+          continue;
+        }
+      }
       try {
         await Post.create(post);
       } catch (err) {
@@ -87,12 +105,13 @@ module.exports = async function(args) {
       }
     }
 
-    const postsNum = posts.length - errNum;
+    const postsNum = posts.length - errNum - skipNum;
     if (untitledPostCounter) {
       log.w('%d posts did not have titles and were prefixed with "Untitled Post".', untitledPostCounter);
     }
     if (postsNum) log.i('%d posts migrated.', postsNum);
-    if (errNum) log.error('%d posts failed to migrate.', posts.length);
+    if (errNum) log.error('%d posts failed to migrate.', errNum);
+    if (skipNum) log.i('%d posts skipped.', skipNum);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "camaro": "^4.1.2",
     "hexo-fs": "^2.0.0",
+    "hexo-util": "^1.8.0",
     "got": "^10.2.1",
     "turndown": "^5.0.3"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -2,9 +2,9 @@
 
 require('chai').should();
 const { join } = require('path');
-const { exists, listDir, readFile, rmdir } = require('hexo-fs');
+const { exists, listDir, readFile, rmdir, writeFile } = require('hexo-fs');
 const Hexo = require('hexo');
-const hexo = new Hexo(__dirname, { silent: true });
+const hexo = new Hexo(process.cwd(), { silent: true });
 const m = require('../lib/migrator.js').bind(hexo);
 const parseFeed = require('../lib/feed');
 const { spy } = require('sinon');
@@ -113,5 +113,40 @@ describe('migrator', function() {
     const expected = await parseFeed(input);
 
     posts.length.should.eql(expected.items.length);
+  });
+
+  it('option - skipduplicate', async () => {
+    const path = join(__dirname, 'fixtures/atom.xml');
+    const postDir = join(hexo.source_dir, '_posts');
+    await writeFile(join(postDir, 'Star-City.md'), 'foo');
+    await m({ _: [path], skipduplicate: true });
+    const posts = await listDir(postDir);
+    const input = await readFile(path);
+    const expected = await parseFeed(input);
+
+    posts.length.should.eql(expected.items.length);
+  });
+
+  it('option - skipduplicate (no existing post)', async () => {
+    const path = join(__dirname, 'fixtures/atom.xml');
+    const postDir = join(hexo.source_dir, '_posts');
+    await m({ _: [path], skipduplicate: true });
+    const posts = await listDir(postDir);
+    const input = await readFile(path);
+    const expected = await parseFeed(input);
+
+    posts.length.should.eql(expected.items.length);
+  });
+
+  it('option - skipduplicate disabled', async () => {
+    const path = join(__dirname, 'fixtures/atom.xml');
+    const postDir = join(hexo.source_dir, '_posts');
+    await writeFile(join(postDir, 'Star-City.md'), 'foo');
+    await m({ _: [path] });
+    const posts = await listDir(postDir);
+    const input = await readFile(path);
+    const expected = await parseFeed(input);
+
+    posts.length.should.not.eql(expected.items.length);
   });
 });


### PR DESCRIPTION
```
hexo migrate rss /path/to/feed.xml --nodup
```

If feed.xml has a post titled 'Star City' and there is an existing post named 'Star-City.md', that particular feed post will be skipped. This is regardless of upper/lower case. (All comparisons are made in lowercase for compatibility with case-insenstive file system.)

By default (without `--nodup), this plugin will create another file named 'Star-City-1.md'.

This feature is updated from #9, credit @grevory
Closes #9 