### PR TITLE
fix: handle title with double quotes

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -88,6 +88,8 @@ module.exports = async function(args) {
         log.i('Post found: %s', title);
       }
 
+      if (title.includes('"')) title = title.replace(/"/g, '\\"');
+
       const newPost = {
         title,
         date,

--- a/test/index.js
+++ b/test/index.js
@@ -75,6 +75,21 @@ describe('migrator', function() {
     exist.should.eql(true);
   });
 
+  it('title with double quotes', async () => {
+    const { slugize } = require('hexo-util');
+
+    const title = 'lorem "ipsum"';
+    const xml = `<feed><title>test</title><entry><title>${title}</title></entry></feed>`;
+    const path = join(__dirname, 'atom-test.xml');
+    await writeFile(path, xml);
+    await m({ _: [path] });
+
+    const post = await readFile(join(hexo.source_dir, '_posts', slugize(title) + '.md'));
+    post.includes('title: ' + title).should.eql(true);
+
+    await unlink(path);
+  });
+
   it('excerpt - summary element', async () => {
     const { unescapeHTML } = require('hexo-util');
 


### PR DESCRIPTION
Similar to https://github.com/hexojs/hexo-migrator-wordpress/issues/17