### PR TITLE
refactor: use Object.hasOwnProperty

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -11,7 +11,7 @@ const { join, parse } = require('path');
 module.exports = async function(args) {
   const source = args._.shift();
   const { alias } = args;
-  const skipduplicate = typeof args.skipduplicate !== 'undefined';
+  const skipduplicate = Object.prototype.hasOwnProperty.call(args, 'skipduplicate');
   let { limit } = args;
   const tomd = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
   const { config, log } = this;


### PR DESCRIPTION
`skipduplicate` key is only checked for its existence, its value is actually not relevant to its purpose, even when the value is `undefined`.

If the key is there, its value is never `undefined` though, but rather `boolean`, `string` or `number`.

`$ hexo migrate rss path.xml --skipduplicate` => `args: { _: ['path.xml'], skipduplicate: true }`
`$ hexo migrate rss path.xml --skipduplicate undefined` => `args: { _: ['path.xml'], skipduplicate: 'undefined' }`
`$ hexo migrate rss path.xml --skipduplicate 123` => `args: { _: ['path.xml'], skipduplicate: 123 }`

---

`Object.prototype.hasOwnProperty` is indeed slower than `typeof`, but it only runs _once_ so it shouldn't cause noticeable latency. Thus, in this use case, better accuracy can be achieved without performance impact.