### PR TITLE
fix: unescape title if escaped

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -23,6 +23,7 @@ module.exports = async function(args) {
   const tagExcerpt = '<a id="more"></a>';
   const rExcerpt = /<!-- ?more ?-->/i;
   const postExcerpt = '\n<!-- more -->\n';
+  const rEntity = /&#?\w{2,4};/;
   const posts = [];
   let currentPosts = [];
 
@@ -63,7 +64,7 @@ module.exports = async function(args) {
       let { content, excerpt, title } = item;
 
       if (excerpt) {
-        if (excerpt.includes('&lt;')) excerpt = unescapeHTML(excerpt);
+        if (rEntity.test(excerpt)) excerpt = unescapeHTML(excerpt);
         if (content.includes(excerpt)) content = content.replace(excerpt, '');
         if (content.includes(tagExcerpt)) content = content.replace(tagExcerpt, '');
 
@@ -88,6 +89,7 @@ module.exports = async function(args) {
         log.i('Post found: %s', title);
       }
 
+      if (rEntity.test(title)) title = unescapeHTML(title);
       if (title.includes('"')) title = title.replace(/"/g, '\\"');
 
       const newPost = {

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@
 require('chai').should();
 const { join } = require('path');
 const { exists, listDir, readFile, rmdir, unlink, writeFile } = require('hexo-fs');
-const { unescapeHTML } = require('hexo-util');
+const { slugize, escapeHTML, unescapeHTML } = require('hexo-util');
 const TurndownService = require('turndown');
 const tomd = new TurndownService();
 const Hexo = require('hexo');
@@ -76,10 +76,21 @@ describe('migrator', function() {
   });
 
   it('title with double quotes', async () => {
-    const { slugize } = require('hexo-util');
-
     const title = 'lorem "ipsum"';
     const xml = `<feed><title>test</title><entry><title>${title}</title></entry></feed>`;
+    const path = join(__dirname, 'atom-test.xml');
+    await writeFile(path, xml);
+    await m({ _: [path] });
+
+    const post = await readFile(join(hexo.source_dir, '_posts', slugize(title) + '.md'));
+    post.includes('title: ' + title).should.eql(true);
+
+    await unlink(path);
+  });
+
+  it('title with escaped character', async () => {
+    const title = 'lorem & "ipsum"';
+    const xml = `<feed><title>test</title><entry><title>${escapeHTML(title)}</title></entry></feed>`;
     const path = join(__dirname, 'atom-test.xml');
     await writeFile(path, xml);
     await m({ _: [path] });


### PR DESCRIPTION
https://github.com/hexojs/hexo-migrator-wordpress/pull/82